### PR TITLE
Remove READ_MEDIA_IMAGES permission and refactor image saving logic i…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />

--- a/lib/modules/plans/plan_quote_details_screen.dart
+++ b/lib/modules/plans/plan_quote_details_screen.dart
@@ -5,10 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:screenshot/screenshot.dart';
 import 'package:share_plus/share_plus.dart';
-import 'package:permission_handler/permission_handler.dart';
-import 'package:path/path.dart' as path;
 import '../../core/theme/app_colors.dart';
-import 'package:device_info_plus/device_info_plus.dart';
 
 class PlanQuoteDetailsScreen extends StatefulWidget {
   const PlanQuoteDetailsScreen({super.key});
@@ -19,36 +16,7 @@ class PlanQuoteDetailsScreen extends StatefulWidget {
 
 class _PlanQuoteDetailsScreenState extends State<PlanQuoteDetailsScreen> {
   final ScreenshotController _screenshotController = ScreenshotController();
-  late AndroidDeviceInfo? androidInfo;
-
-  @override
-  void initState() {
-    super.initState();
-    initDeviceInfo();
-  }
-
-  Future<void> initDeviceInfo() async {
-    final info = await DeviceInfoPlugin().androidInfo;
-    setState(() {
-      androidInfo = info;
-    });
-  }
   Future<void> _captureAndShare() async {
-    // Detecta si es Android 13+
-    if (Platform.isAndroid && androidInfo?.version.sdkInt != null && androidInfo!.version.sdkInt >= 33) {
-      final photos = await Permission.photos.request();
-      if (!photos.isGranted) {
-        debugPrint('❌ Permiso de fotos no concedido (Android 13+)');
-        return;
-      }
-    } else {
-      final storage = await Permission.storage.request();
-      if (!storage.isGranted) {
-        debugPrint('❌ Permiso de almacenamiento no concedido');
-        return;
-      }
-    }
-
     try {
       final Uint8List? imageBytes = await _screenshotController.capture();
       if (imageBytes == null) {
@@ -56,9 +24,10 @@ class _PlanQuoteDetailsScreenState extends State<PlanQuoteDetailsScreen> {
         return;
       }
 
-      final directory = await getExternalStorageDirectory();
-      final imagePath = '${directory!.path}/plan_quote_${DateTime.now().millisecondsSinceEpoch}.png';
-      final file = File(imagePath)..writeAsBytesSync(imageBytes);
+      // Usar directorio temporal de la app (no requiere permisos)
+      final directory = await getTemporaryDirectory();
+      final imagePath = '${directory.path}/plan_quote_${DateTime.now().millisecondsSinceEpoch}.png';
+      File(imagePath).writeAsBytesSync(imageBytes);
 
       debugPrint('✅ Imagen guardada: $imagePath');
 


### PR DESCRIPTION
…n PlanQuoteDetailsScreen to use temporary directory, eliminating the need for storage permissions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Save shared screenshot to app temp directory, removing runtime storage/photo checks and the READ_MEDIA_IMAGES permission.
> 
> - **Android**:
>   - Remove `android.permission.READ_MEDIA_IMAGES` from `android/app/src/main/AndroidManifest.xml`.
> - **Flutter (PlanQuoteDetailsScreen)**:
>   - Refactor `_captureAndShare` to write screenshot to `getTemporaryDirectory()` and share via `Share.shareXFiles`.
>   - Remove permission/device-info logic and related imports (`permission_handler`, `device_info_plus`, path helpers).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 098ddcbd5912119e85ca0bc7b6d5e9dc4b410dc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->