### PR TITLE
Fixe home screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />

--- a/lib/auth/biometric_auth_screen.dart
+++ b/lib/auth/biometric_auth_screen.dart
@@ -105,12 +105,29 @@ class _BiometricAuthScreenState extends State<BiometricAuthScreen>
         final decoded = jsonDecode(response.body);
         final userData = decoded['data'];
         
-        // user_plans ahora es un Map, necesitamos convertirlo a lista
-        final Map<String, dynamic> userPlansMap = userData['user_plans'] ?? {};
-        final List<dynamic> userPlans = userPlansMap.values.toList();
+        print('🔐 BiometricAuth - user_plans tipo: ${userData['user_plans'].runtimeType}');
+        
+        // user_plans puede venir como Map o como List
+        final dynamic userPlansData = userData['user_plans'];
+        final List<dynamic> userPlans;
+        
+        if (userPlansData is List) {
+          print('✅ BiometricAuth - user_plans es una Lista');
+          userPlans = userPlansData;
+        } else if (userPlansData is Map) {
+          print('✅ BiometricAuth - user_plans es un Map');
+          final Map<String, dynamic> userPlansMap = userPlansData as Map<String, dynamic>;
+          userPlans = userPlansMap.values.toList();
+        } else {
+          print('⚠️ BiometricAuth - user_plans es null o tipo desconocido, usando lista vacía');
+          userPlans = [];
+        }
+        
         final List<String> planNames = userPlans
-            .map<String>((plan) => plan['nombre_plan'].toString())
+            .map<String>((plan) => plan['nombre_plan']?.toString() ?? '')
             .toList();
+        
+        print('📋 BiometricAuth - Total de planes: ${userPlans.length}, nombres: $planNames');
 
         // Navegar directamente al HomeScreen
         Navigator.pushReplacement(

--- a/lib/core/beneficiario_service.dart
+++ b/lib/core/beneficiario_service.dart
@@ -52,9 +52,24 @@ class BeneficiarioService {
         
         // Si no se encuentra directamente, buscar en user_plans
         if (userPlanId == null && data['data']['user_plans'] != null) {
-          // user_plans ahora es un Map, necesitamos convertirlo a lista
-          final Map<String, dynamic> userPlansMap = data['data']['user_plans'];
-          final userPlans = userPlansMap.values.toList();
+          print('📋 [BeneficiarioService] user_plans tipo: ${data['data']['user_plans'].runtimeType}');
+          
+          // user_plans puede venir como Map o como List
+          final dynamic userPlansData = data['data']['user_plans'];
+          final List<dynamic> userPlans;
+          
+          if (userPlansData is List) {
+            print('✅ [BeneficiarioService] user_plans es una Lista');
+            userPlans = userPlansData;
+          } else if (userPlansData is Map) {
+            print('✅ [BeneficiarioService] user_plans es un Map');
+            final Map<String, dynamic> userPlansMap = userPlansData as Map<String, dynamic>;
+            userPlans = userPlansMap.values.toList();
+          } else {
+            print('⚠️ [BeneficiarioService] user_plans es null o tipo desconocido, usando lista vacía');
+            userPlans = [];
+          }
+          
           print('📋 [BeneficiarioService] User plans encontrados: ${userPlans.length}');
           
           if (userPlans.isNotEmpty) {

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -41,14 +41,35 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _showPlansModalIfNeeded() {
-    // user_plans ahora es un Map, necesitamos convertirlo a lista
-    final Map<String, dynamic> userPlansMap = widget.user['user_plans'] ?? {};
-    final plans = List<Map<String, dynamic>>.from(userPlansMap.values);
+    print('🏠 HomeScreen - _showPlansModalIfNeeded llamado');
+    print('🏠 HomeScreen - user_plans tipo: ${widget.user['user_plans'].runtimeType}');
+    
+    // user_plans puede venir como Map o como List dependiendo del backend
+    final dynamic userPlansData = widget.user['user_plans'];
+    final List<dynamic> plans;
+    
+    if (userPlansData is List) {
+      print('✅ HomeScreen - user_plans es una Lista');
+      plans = userPlansData;
+    } else if (userPlansData is Map) {
+      print('✅ HomeScreen - user_plans es un Map');
+      final Map<String, dynamic> userPlansMap = userPlansData as Map<String, dynamic>;
+      plans = userPlansMap.values.toList();
+    } else {
+      print('⚠️ HomeScreen - user_plans es null o tipo desconocido, usando lista vacía');
+      plans = [];
+    }
+    
+    print('📋 HomeScreen - Total de planes: ${plans.length}');
+    
     if (plans.isEmpty && !_hasShownModal) {
+      print('⚠️ HomeScreen - No hay planes, mostrando modal');
       setState(() {
         _hasShownModal = true;
       });
       _showPlansInfoModal();
+    } else {
+      print('✅ HomeScreen - Hay ${plans.length} planes, no se muestra modal');
     }
   }
 
@@ -172,9 +193,25 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // user_plans ahora es un Map, necesitamos convertirlo a lista
-    final Map<String, dynamic> userPlansMap = widget.user['user_plans'] ?? {};
-    final plans = List<Map<String, dynamic>>.from(userPlansMap.values)
+    print('🏗️ HomeScreen - build() llamado');
+    
+    // user_plans puede venir como Map o como List dependiendo del backend
+    final dynamic userPlansData = widget.user['user_plans'];
+    final List<dynamic> plansList;
+    
+    if (userPlansData is List) {
+      print('✅ HomeScreen build - user_plans es una Lista');
+      plansList = userPlansData;
+    } else if (userPlansData is Map) {
+      print('✅ HomeScreen build - user_plans es un Map');
+      final Map<String, dynamic> userPlansMap = userPlansData as Map<String, dynamic>;
+      plansList = userPlansMap.values.toList();
+    } else {
+      print('⚠️ HomeScreen build - user_plans es null o tipo desconocido, usando lista vacía');
+      plansList = [];
+    }
+    
+    final plans = List<Map<String, dynamic>>.from(plansList)
       ..sort((a, b) {
         final statusA = (a['status'] ?? '').toString().toLowerCase();
         final statusB = (b['status'] ?? '').toString().toLowerCase();
@@ -198,6 +235,8 @@ class _HomeScreenState extends State<HomeScreen> {
         // Ordenar por prioridad (menor número = mayor prioridad)
         return priorityA.compareTo(priorityB);
       });
+    
+    print('📋 HomeScreen build - Total de planes ordenados: ${plans.length}');
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       body: SafeArea(
@@ -229,8 +268,27 @@ class _HomeScreenState extends State<HomeScreen> {
               // TARJETA DE AHORRO
               Builder(
                 builder: (context) {
-                  final Map<String, dynamic> ahorroPlansMap = widget.user['user_plans'] ?? {};
-                  final List<Map<String, dynamic>> ahorroPlans = List<Map<String, dynamic>>.from(ahorroPlansMap.values);
+                  print('💰 AhorroCard - Preparando datos de ahorro');
+                  
+                  // user_plans puede venir como Map o como List
+                  final dynamic userPlansData = widget.user['user_plans'];
+                  final List<dynamic> plansList;
+                  
+                  if (userPlansData is List) {
+                    print('✅ AhorroCard - user_plans es una Lista');
+                    plansList = userPlansData;
+                  } else if (userPlansData is Map) {
+                    print('✅ AhorroCard - user_plans es un Map');
+                    final Map<String, dynamic> userPlansMap = userPlansData as Map<String, dynamic>;
+                    plansList = userPlansMap.values.toList();
+                  } else {
+                    print('⚠️ AhorroCard - user_plans es null o tipo desconocido, usando lista vacía');
+                    plansList = [];
+                  }
+                  
+                  final List<Map<String, dynamic>> ahorroPlans = List<Map<String, dynamic>>.from(plansList);
+                  print('💰 AhorroCard - Planes de ahorro: ${ahorroPlans.length}');
+                  
                   return AhorroCard(plans: ahorroPlans);
                 },
               ),

--- a/lib/modules/plans/plan_detail_screen.dart
+++ b/lib/modules/plans/plan_detail_screen.dart
@@ -156,9 +156,26 @@ class _PlanDetailScreenState extends State<PlanDetailScreen> {
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
         final userData = data['data'];
-        // user_plans ahora es un Map, necesitamos convertirlo a lista
-        final Map<String, dynamic> userPlansMap = userData['user_plans'] ?? {};
-        final userPlans = userPlansMap.values.toList();
+        
+        print('📊 PlanDetailScreen - user_plans tipo: ${userData['user_plans'].runtimeType}');
+        
+        // user_plans puede venir como Map o como List dependiendo del backend
+        final dynamic userPlansData = userData['user_plans'];
+        final List<dynamic> userPlans;
+        
+        if (userPlansData is List) {
+          print('✅ PlanDetailScreen - user_plans es una Lista');
+          userPlans = userPlansData;
+        } else if (userPlansData is Map) {
+          print('✅ PlanDetailScreen - user_plans es un Map');
+          final Map<String, dynamic> userPlansMap = userPlansData as Map<String, dynamic>;
+          userPlans = userPlansMap.values.toList();
+        } else {
+          print('⚠️ PlanDetailScreen - user_plans es null o tipo desconocido, usando lista vacía');
+          userPlans = [];
+        }
+        
+        print('📋 PlanDetailScreen - Total de planes: ${userPlans.length}');
         
         // Calcular edad del usuario
         final dateBirth = widget.user['dateBirth'];

--- a/lib/modules/plans/plan_quote_details_screen.dart
+++ b/lib/modules/plans/plan_quote_details_screen.dart
@@ -5,10 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:screenshot/screenshot.dart';
 import 'package:share_plus/share_plus.dart';
-import 'package:permission_handler/permission_handler.dart';
-import 'package:path/path.dart' as path;
 import '../../core/theme/app_colors.dart';
-import 'package:device_info_plus/device_info_plus.dart';
 
 class PlanQuoteDetailsScreen extends StatefulWidget {
   const PlanQuoteDetailsScreen({super.key});
@@ -19,36 +16,7 @@ class PlanQuoteDetailsScreen extends StatefulWidget {
 
 class _PlanQuoteDetailsScreenState extends State<PlanQuoteDetailsScreen> {
   final ScreenshotController _screenshotController = ScreenshotController();
-  late AndroidDeviceInfo? androidInfo;
-
-  @override
-  void initState() {
-    super.initState();
-    initDeviceInfo();
-  }
-
-  Future<void> initDeviceInfo() async {
-    final info = await DeviceInfoPlugin().androidInfo;
-    setState(() {
-      androidInfo = info;
-    });
-  }
   Future<void> _captureAndShare() async {
-    // Detecta si es Android 13+
-    if (Platform.isAndroid && androidInfo?.version.sdkInt != null && androidInfo!.version.sdkInt >= 33) {
-      final photos = await Permission.photos.request();
-      if (!photos.isGranted) {
-        debugPrint('❌ Permiso de fotos no concedido (Android 13+)');
-        return;
-      }
-    } else {
-      final storage = await Permission.storage.request();
-      if (!storage.isGranted) {
-        debugPrint('❌ Permiso de almacenamiento no concedido');
-        return;
-      }
-    }
-
     try {
       final Uint8List? imageBytes = await _screenshotController.capture();
       if (imageBytes == null) {
@@ -56,9 +24,10 @@ class _PlanQuoteDetailsScreenState extends State<PlanQuoteDetailsScreen> {
         return;
       }
 
-      final directory = await getExternalStorageDirectory();
-      final imagePath = '${directory!.path}/plan_quote_${DateTime.now().millisecondsSinceEpoch}.png';
-      final file = File(imagePath)..writeAsBytesSync(imageBytes);
+      // Usar directorio temporal de la app (no requiere permisos)
+      final directory = await getTemporaryDirectory();
+      final imagePath = '${directory.path}/plan_quote_${DateTime.now().millisecondsSinceEpoch}.png';
+      File(imagePath).writeAsBytesSync(imageBytes);
 
       debugPrint('✅ Imagen guardada: $imagePath');
 

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -102,15 +102,23 @@ class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderSt
         } else {
           // Usuario ya cambió su contraseña, verificar datos del usuario
           print('🏠 Yendo al home');
+          print('📡 Response body completo: ${response.body}');
           final decoded = jsonDecode(response.body);
+          print('📊 Decoded completo: ${jsonEncode(decoded)}');
           final userData = decoded['data'];
+          print('👤 userData extraído: ${jsonEncode(userData)}');
+          print('📦 user_plans antes de pasar a _goToHome: ${jsonEncode(userData['user_plans'])}');
           _goToHome(userData);
         }
       } else {
         // Error al verificar estado del primer login, usar los datos ya obtenidos
         print('🏠 Error en primer login, yendo al home con datos existentes');
+        print('📡 Response body completo: ${response.body}');
         final decoded = jsonDecode(response.body);
+        print('📊 Decoded completo: ${jsonEncode(decoded)}');
         final userData = decoded['data'];
+        print('👤 userData extraído: ${jsonEncode(userData)}');
+        print('📦 user_plans antes de pasar a _goToHome: ${jsonEncode(userData['user_plans'])}');
         _goToHome(userData);
       }
     } catch (e, stackTrace) {
@@ -130,12 +138,37 @@ class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderSt
   }
 
   void _goToHome(Map<String, dynamic> userData) {
-    // user_plans ahora es un Map, necesitamos convertirlo a lista
-    final Map<String, dynamic> userPlansMap = userData['user_plans'] ?? {};
-    final List<dynamic> userPlans = userPlansMap.values.toList();
+    print('🏠 _goToHome - userData completo: ${jsonEncode(userData)}');
+    print('🏠 _goToHome - user_plans tipo: ${userData['user_plans'].runtimeType}');
+    print('🏠 _goToHome - user_plans contenido: ${jsonEncode(userData['user_plans'])}');
+    
+    // user_plans puede venir como Map o como List dependiendo del backend
+    final dynamic userPlansData = userData['user_plans'];
+    final List<dynamic> userPlans;
+    
+    if (userPlansData is List) {
+      print('✅ user_plans es una Lista');
+      userPlans = userPlansData;
+    } else if (userPlansData is Map) {
+      print('✅ user_plans es un Map');
+      final Map<String, dynamic> userPlansMap = userPlansData as Map<String, dynamic>;
+      userPlans = userPlansMap.values.toList();
+    } else {
+      print('⚠️ user_plans es null o tipo desconocido, usando lista vacía');
+      userPlans = [];
+    }
+    
+    print('📋 Total de planes encontrados: ${userPlans.length}');
+    
     final List<String> planNames = userPlans
-        .map<String>((plan) => plan['nombre_plan'].toString())
+        .map<String>((plan) {
+          final nombre = plan['nombre_plan']?.toString() ?? '';
+          print('📝 Plan encontrado: $nombre (status: ${plan['status']})');
+          return nombre;
+        })
         .toList();
+    
+    print('📋 Nombres de planes finales: $planNames');
 
     Navigator.pushReplacement(
       context,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make `user_plans` handling resilient to Map/List across app flows; simplify quote sharing to use temp storage and drop media permission.
> 
> - **Core/App Flow**:
>   - Handle `user_plans` as either List or Map with safe parsing and logging in `lib/auth/biometric_auth_screen.dart`, `lib/core/beneficiario_service.dart`, `lib/home_screen.dart`, `lib/modules/plans/plan_detail_screen.dart`, and `lib/splash_screen.dart`.
>   - Home improvements: conditional modal display based on parsed plans; stable plan sorting by `status`; additional diagnostics throughout build and init.
> - **Plans Quote Sharing**:
>   - `lib/modules/plans/plan_quote_details_screen.dart`: remove runtime permission/device info logic; save screenshot to app temp directory and share via `Share.shareXFiles` (no storage permission required).
> - **Android**:
>   - `android/app/src/main/AndroidManifest.xml`: remove `READ_MEDIA_IMAGES` permission; keep storage/biometric permissions; no other manifest changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47e30744491f3c26e3728139d54fc4a8dfc1f022. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->